### PR TITLE
docker_test tag added.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,9 @@
     pkg: openvpn
     state: latest
     update_cache: yes
+  tags:
+    - install
+    - docker_test
 
 - name: Create folder
   file:


### PR DESCRIPTION
When testing in a docker environment do not try to install the openvpn software