### PR TITLE
feat: replace Vagrant with Lima for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Makefile – ansible-openvpn-docker
+#
+# Targets
+#   make test-start    Start the Lima test VM
+#   make test-run      Run the Ansible role against the Lima VM
+#   make test-stop     Stop and delete the Lima test VM
+#   make test          Full cycle: start → run → stop
+#   make docker-build  Build the Docker image (standalone mode)
+# ──────────────────────────────────────────────────────────────────────────────
+
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
+.DEFAULT_GOAL := help
+
+LIMA_VM      := openvpn-test
+LIMA_CONFIG  := tests/lima/$(LIMA_VM).yaml
+PLAYBOOK     := tests/main.yml
+
+GREEN := \033[0;32m
+CYAN  := \033[0;36m
+NC    := \033[0m
+
+.PHONY: help test-start test-run test-stop test docker-build
+
+help: ## Show available targets
+	@echo ""
+	@echo "  ansible-openvpn-docker – local test targets"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  $(CYAN)%-16s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+
+test-start: ## Start the Lima test VM (Debian 12)
+	@echo -e "$(GREEN)[test]$(NC) Starting Lima VM '$(LIMA_VM)'..."
+	@limactl start $(LIMA_CONFIG)
+	@echo -e "$(GREEN)[test]$(NC) VM ready."
+
+test-run: ## Run the Ansible role against the Lima VM
+	@echo -e "$(GREEN)[test]$(NC) Resolving Lima SSH config..."
+	@limactl show-ssh $(LIMA_VM) --format config > /tmp/lima-$(LIMA_VM)-ssh.cfg
+	@LIMA_PORT=$$(grep -m1 'Port' /tmp/lima-$(LIMA_VM)-ssh.cfg | awk '{print $$2}') && \
+	 LIMA_USER=$$(grep -m1 'User' /tmp/lima-$(LIMA_VM)-ssh.cfg | awk '{print $$2}') && \
+	 echo -e "$(GREEN)[test]$(NC) Running playbook (host=127.0.0.1:$$LIMA_PORT user=$$LIMA_USER)..." && \
+	 ansible-playbook $(PLAYBOOK) \
+	   -i "127.0.0.1," \
+	   -e "ansible_port=$$LIMA_PORT" \
+	   -e "ansible_user=$$LIMA_USER" \
+	   -e "ansible_ssh_private_key_file=$$HOME/.lima/_config/user" \
+	   --skip-tags "addclient,docker"
+
+test-stop: ## Stop and delete the Lima test VM
+	@echo -e "$(GREEN)[test]$(NC) Stopping Lima VM '$(LIMA_VM)'..."
+	@limactl stop $(LIMA_VM) 2>/dev/null || true
+	@limactl delete $(LIMA_VM) 2>/dev/null || true
+	@rm -f /tmp/lima-$(LIMA_VM)-ssh.cfg
+	@echo -e "$(GREEN)[test]$(NC) VM removed."
+
+test: test-start test-run test-stop ## Full test cycle: start → run → stop
+
+docker-build: ## Build the Docker image
+	@docker build -t openvpn -f tests/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -44,3 +44,33 @@ Next run/build the container
 `docker run -itd --name openvpn --privileged --cap-add=NET_ADMIN <Containner name> ovpn`
 2. Managed
 `docker run -itd --volumes-from ovpn_datacontainer --name openvpn --privileged --cap-add=NET_ADMIN <Containner name> ovpn`
+
+## Local testing with Lima
+
+Vagrant has been replaced with [Lima](https://github.com/lima-vm/lima) for local testing. Lima runs a Debian 12 (bookworm) VM on macOS (Apple Silicon and Intel) without requiring VirtualBox or Vagrant.
+
+### Prerequisites
+
+```bash
+brew install lima ansible
+```
+
+### Run the tests
+
+```bash
+# Full cycle (start VM → run role → destroy VM)
+make test
+
+# Or step by step
+make test-start   # boot Debian 12 Lima VM
+make test-run     # run ansible-openvpn-docker role against the VM
+make test-stop    # destroy the VM
+```
+
+### Build the Docker image
+
+```bash
+make docker-build
+```
+
+The Lima VM config is at `tests/lima/openvpn-test.yaml`. The Vagrantfile is kept for reference but is no longer maintained.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+# Allow Ansible to find the role by its directory name when run from project root
+roles_path = .
+
+[ssh_connection]
+# Avoid SSH host key prompts for ephemeral test VMs
+ssh_args = -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,10 +1,8 @@
-FROM debian:jessie
+FROM debian:bookworm
 
 #VOLUME ["/etc/openvpn/certs", "/etc/openvpn/clients"
 
-RUN echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" >> /etc/apt/sources.list.d/ansible.list && \
- apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 && \
- apt-get update && \
+RUN apt-get update && \
  apt-get -y upgrade && \
  apt-get install -y git ansible openvpn && \
  mkdir -p /etc/ansible/roles/ansible-openvpn-docker &&  \

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,3 +1,5 @@
+# DEPRECATED: Vagrant testing has been replaced by Lima (see tests/lima/openvpn-test.yaml)
+# Use `make test-start && make test-run` instead of `vagrant up`
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/jessie64"
   config.vm.define "OpenVPN" do |vpn|

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -1,0 +1,41 @@
+# Lima VM for testing the ansible-openvpn-docker role
+# Replaces the Vagrant/jessie64 setup with Debian 12 (bookworm)
+#
+# Usage:
+#   limactl start tests/lima/openvpn-test.yaml
+#   limactl shell openvpn-test
+#   limactl stop openvpn-test && limactl delete openvpn-test
+#
+# Or via Makefile:
+#   make test-start
+#   make test-run
+#   make test-stop
+
+images:
+  # Apple Silicon (M1–M4)
+  - location: "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2"
+    arch: aarch64
+  # Intel
+  - location: "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+    arch: x86_64
+
+cpus: 2
+memory: "1GiB"
+disk: "10GiB"
+
+# Mount the project root read-only so Ansible can reference role files
+mounts:
+  - location: "~"
+    writable: false
+
+ssh:
+  loadDotSSHPubKeys: true
+
+# Install Python3 (required by Ansible) on first boot
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -e
+      apt-get update -qq
+      apt-get install -y -qq python3 python3-apt


### PR DESCRIPTION
## What
Replaces Vagrant + debian/jessie64 with Lima + Debian 12 (bookworm) for local Ansible role testing.

## Why
Vagrant with jessie64 is EOL (Debian 8, unsupported since 2020) and requires VirtualBox which doesn't work well on Apple Silicon. Lima runs natively on macOS with Apple's Hypervisor framework and supports both ARM64 and x86_64.

## Changes
- Added `tests/lima/openvpn-test.yaml` — Lima VM config (Debian 12, 2 CPUs, 1GiB RAM) with Python3 provisioned on boot
- Added `Makefile` with `test-start`, `test-run`, `test-stop`, `test`, and `docker-build` targets
- Added `ansible.cfg` — sets `roles_path = .` so Ansible resolves the role from the project root, and disables SSH host key checking for ephemeral VMs
- Updated `tests/Dockerfile` — base image bumped from `debian:jessie` to `debian:bookworm`, removed defunct Launchpad Ansible PPA
- Updated `tests/Vagrantfile` — marked as deprecated with a note pointing to Lima
- Updated `README.md` — added Lima testing section with prerequisites and make targets