### PR TITLE
fix: set roles_path to parent dir so role resolves by project folder name

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 # Allow Ansible to find the role by its directory name when run from project root
-roles_path = .
+# Set to parent dir so Ansible resolves 'ansible-openvpn-docker' as this project's folder
+roles_path = ..
 
 [ssh_connection]
 # Avoid SSH host key prompts for ephemeral test VMs


### PR DESCRIPTION
## What
Fixes Ansible role not found error when running `make test-run`.

## Why
The role is referenced as `ansible-openvpn-docker` in `tests/main.yml`. Ansible resolves this by looking for a directory with that name in the `roles_path`. Setting `roles_path = .` pointed at the project root itself, not its parent — so the role directory was never found. Setting it to `..` means Ansible looks in `/Users/kirk/development/` and finds `ansible-openvpn-docker` correctly.

## Changes
- `ansible.cfg` — changed `roles_path` from `.` to `..`