### PR TITLE
fix: update role for Debian 12 compatibility and Lima local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,18 +36,14 @@ test-start: ## Start the Lima test VM (Debian 12)
 	@limactl start $(LIMA_CONFIG)
 	@echo -e "$(GREEN)[test]$(NC) VM ready."
 
-test-run: ## Run the Ansible role against the Lima VM
-	@echo -e "$(GREEN)[test]$(NC) Resolving Lima SSH config..."
-	@limactl show-ssh $(LIMA_VM) --format config > /tmp/lima-$(LIMA_VM)-ssh.cfg
-	@LIMA_PORT=$$(grep -m1 'Port' /tmp/lima-$(LIMA_VM)-ssh.cfg | awk '{print $$2}') && \
-	 LIMA_USER=$$(grep -m1 'User' /tmp/lima-$(LIMA_VM)-ssh.cfg | awk '{print $$2}') && \
-	 echo -e "$(GREEN)[test]$(NC) Running playbook (host=127.0.0.1:$$LIMA_PORT user=$$LIMA_USER)..." && \
-	 ansible-playbook $(PLAYBOOK) \
-	   -i "127.0.0.1," \
-	   -e "ansible_port=$$LIMA_PORT" \
-	   -e "ansible_user=$$LIMA_USER" \
-	   -e "ansible_ssh_extra_args='-F /tmp/lima-$(LIMA_VM)-ssh.cfg'" \
-	   --skip-tags "addclient,docker"
+test-run: ## Run the Ansible role against the Lima VM (runs playbook inside VM via limactl shell)
+	@echo -e "$(GREEN)[test]$(NC) Running playbook inside Lima VM '$(LIMA_VM)'..."
+	@limactl shell $(LIMA_VM) -- sudo bash -c \
+	  "cd /Users/$(shell whoami)/development/ansible-openvpn-docker && \
+	   ansible-playbook $(PLAYBOOK) \
+	     -i 'localhost,' \
+	     --connection=local \
+	     --skip-tags 'addclient,docker'"
 
 test-stop: ## Stop and delete the Lima test VM
 	@echo -e "$(GREEN)[test]$(NC) Stopping Lima VM '$(LIMA_VM)'..."

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-run: ## Run the Ansible role against the Lima VM
 	   -i "127.0.0.1," \
 	   -e "ansible_port=$$LIMA_PORT" \
 	   -e "ansible_user=$$LIMA_USER" \
-	   -e "ansible_ssh_private_key_file=$$HOME/.lima/_config/user" \
+	   -e "ansible_ssh_extra_args='-F /tmp/lima-$(LIMA_VM)-ssh.cfg'" \
 	   --skip-tags "addclient,docker"
 
 test-stop: ## Stop and delete the Lima test VM

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,5 +4,6 @@
 roles_path = ..
 
 [ssh_connection]
-# Avoid SSH host key prompts for ephemeral test VMs
-ssh_args = -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+# SSH settings are passed per-run via ansible_ssh_extra_args using the Lima SSH config file
+# Lima's SSH config already handles StrictHostKeyChecking, UserKnownHostsFile and identity files
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,5 @@
 roles_path = ..
 
 [ssh_connection]
-# SSH settings are passed per-run via ansible_ssh_extra_args using the Lima SSH config file
-# Lima's SSH config already handles StrictHostKeyChecking, UserKnownHostsFile and identity files
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+# No SSH needed — playbook runs inside the Lima VM via limactl shell --connection=local
+pipelining = true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,6 @@
 ---
 
-handlers:
-  - name: restart openvpn
-    service:
-      name: openvpn
-      state: restarted
+- name: restart openvpn
+  service:
+    name: openvpn
+    state: restarted

--- a/tasks/easy-rsa.yml
+++ b/tasks/easy-rsa.yml
@@ -28,6 +28,14 @@
   tags:
     - cert_config
 
+- name: Remove PKI vars template to avoid conflict with system vars
+  file:
+    path: "{{ easy_rsa_cert_dir }}/vars"
+    state: absent
+  when: not certs_build.stat.exists
+  tags:
+    - cert_config
+
 - name: Build CA (no password)
   command: >
     {{ easy_rsa_dir }}/easyrsa

--- a/tasks/easy-rsa.yml
+++ b/tasks/easy-rsa.yml
@@ -1,64 +1,98 @@
 ---
+# easy-rsa v3 — Debian 12 (bookworm) ships easy-rsa 3.x
+# v3 uses a single 'easyrsa' script with subcommands instead of
+# individual scripts (pkitool, build-dh, whichopensslcnf) from v2
+
+- name: Install easy-rsa
+  apt:
+    pkg: easy-rsa
+    state: present
+  tags:
+    - cert_config
 
 - name: Certificate file check
-  stat: 
-    path: "{{ openvpn_dir }}/certs/dh{{ easy_rsa_keys.size }}.pem"
+  stat:
+    path: "{{ easy_rsa_cert_dir }}/ca.crt"
   register: certs_build
   tags:
     - cert_config
 
-- name: vars configuraion
-  template:
-    src=templates/vars.j2
-    dest="{{ easy_rsa_dir }}/vars"
+- name: Initialise PKI directory
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    init-pki
+  when: not certs_build.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
   tags:
     - cert_config
 
-- name: Setting up certs folder
-  file: 
-    path: "{{ easy_rsa_cert_dir }}/index.txt"
-    owner: root
-    group: root
-    mode: 600
-    state: touch
-  when: certs_build.stat.exists == False
+- name: Build CA (no password)
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    build-ca nopass
+  when: not certs_build.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
+    EASYRSA_KEY_SIZE: "{{ easy_rsa_keys.size }}"
+    EASYRSA_CA_EXPIRE: "{{ easy_rsa_keys.ca_expire }}"
+    EASYRSA_CERT_EXPIRE: "{{ easy_rsa_keys.key_expire }}"
+    EASYRSA_REQ_COUNTRY: "{{ easy_rsa_keys.country }}"
+    EASYRSA_REQ_PROVINCE: "{{ easy_rsa_keys.province }}"
+    EASYRSA_REQ_CITY: "{{ easy_rsa_keys.city }}"
+    EASYRSA_REQ_ORG: "{{ easy_rsa_keys.organization }}"
+    EASYRSA_REQ_EMAIL: "{{ easy_rsa_keys.email }}"
+    EASYRSA_REQ_OU: "{{ easy_rsa_keys.organizational_unit }}"
+    EASYRSA_REQ_CN: "{{ easy_rsa_keys.common_name }}"
   tags:
     - cert_config
 
-- name: Cert serial
-  shell: "echo 01 > {{ easy_rsa_cert_dir }}/serial"
-  when: certs_build.stat.exists == False
+- name: Generate server key and certificate request
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    gen-req {{ easy_rsa_keys.common_name }} nopass
+  when: not certs_build.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
   tags:
     - cert_config
 
-- name: Build CA Certificate
-  shell: "source vars && {{ item }}"
-  args:
-    chdir: "{{ easy_rsa_dir }}"
-    executable: /bin/bash
-  with_items:
-    - "./pkitool --initca"
-    - "./pkitool --server {{ easy_rsa_keys.common_name }}"
-    - "./build-dh"
-  when: certs_build.stat.exists == False
+- name: Sign server certificate
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    sign-req server {{ easy_rsa_keys.common_name }}
+  when: not certs_build.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
   tags:
     - cert_config
 
-- name: Ta.key file check
-  stat: 
-    path: "{{ openvpn_dir }}/certs/ta.key"
+- name: Generate DH parameters
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    gen-dh
+  when: not certs_build.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
+  tags:
+    - cert_config
+
+- name: TLS auth key check
+  stat:
+    path: "{{ easy_rsa_cert_dir }}/ta.key"
   register: ta
   tags:
     - cert_config
 
-- name: Generate tls-auth key for added security
-  shell: openvpn --genkey --secret ta.key
-  args:
-    chdir: "{{ easy_rsa_cert_dir }}"
-    executable: /bin/bash
-  when: 
+- name: Generate tls-auth key
+  command: openvpn --genkey secret {{ easy_rsa_cert_dir }}/ta.key
+  when:
     - easy_rsa_keys.tls_auth == True
-    - ta.stat.exists == False
+    - not ta.stat.exists
   tags:
     - cert_config
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -85,7 +85,9 @@
   tags:
     - install
 
-- name: Service restart
-  notify: restart openvpn
+- name: Restart openvpn service
+  service:
+    name: openvpn
+    state: restarted
   tags:
     - vm

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,14 +5,15 @@
   include_vars:
     file: defaults/main.yml
 
-- name: Installere openvpn til sidste version
+- name: Install openvpn and easy-rsa
   apt:
-    pkg: openvpn
+    pkg:
+      - openvpn
+      - easy-rsa
     state: latest
     update_cache: yes
   tags:
     - install
-    - docker
 
 - name: Create folder
   file:

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -38,4 +38,4 @@ provision:
       #!/bin/bash
       set -e
       apt-get update -qq
-      apt-get install -y -qq python3 python3-apt
+      apt-get install -y -qq python3 python3-apt ansible

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,10 +3,15 @@
 openvpn_dir: /etc/openvpn
 
 easy_rsa_cert_dir: "{{ openvpn_dir }}/certs"
-easy_rsa_ca_key_file: "{{ easy_rsa_cert_dir }}/ca.key"
+easy_rsa_ca_key_file: "{{ easy_rsa_cert_dir }}/private/ca.key"
 easy_rsa_ca_crt_file: "{{ easy_rsa_cert_dir }}/ca.crt"
-easy_rsa_server_key_file: "{{ easy_rsa_cert_dir }}/{{ openvpn_server_name }}.key"
-easy_rsa_server_crt_file: "{{ easy_rsa_cert_dir }}/{{ openvpn_server_name }}.crt"
+
+# easy-rsa v3 stores issued certs and private keys in subdirectories
+easy_rsa_server_key_file: "{{ easy_rsa_cert_dir }}/private/{{ easy_rsa_keys.common_name }}.key"
+easy_rsa_server_crt_file: "{{ easy_rsa_cert_dir }}/issued/{{ easy_rsa_keys.common_name }}.crt"
 easy_rsa_ta_crt_file: "{{ easy_rsa_cert_dir }}/ta.key"
-easy_rsa_dh_file: "{{ easy_rsa_cert_dir }}/dh{{dhprimes_bit}}.pem"
+
+# easy-rsa v3 generates dh.pem (not dh<size>.pem as in v2)
+easy_rsa_dh_file: "{{ easy_rsa_cert_dir }}/dh.pem"
+
 easy_rsa_client_dir: "{{ openvpn_dir }}/clients"


### PR DESCRIPTION
## What
Fixes multiple Ansible role compatibility issues discovered while running tests against Debian 12 (bookworm) via Lima.

## Why
The role was written for Debian 8 (jessie) with easy-rsa v2. Debian 12 ships easy-rsa v3 which has an entirely different CLI, causing all certificate generation to fail. Several other syntax issues also surfaced during testing.

## Changes

**Handlers**
- `handlers/main.yml` — removed `handlers:` wrapper key; Ansible expects a bare list, not a dict

**easy-rsa v2 → v3 rewrite**
- `tasks/easy-rsa.yml` — replaced `pkitool`, `build-dh`, and `whichopensslcnf` (v2) with `easyrsa init-pki`, `build-ca`, `gen-req`, `sign-req`, and `gen-dh` (v3); config now passed via `EASYRSA_*` env vars instead of a sourced `vars` file
- Added task to remove the PKI `vars` template created by `init-pki` to avoid conflict with `/usr/share/easy-rsa/vars`
- `vars/main.yml` — updated cert/key paths to match v3 PKI structure (`issued/`, `private/` subdirs); DH file updated from `dh<size>.pem` to `dh.pem`

**Install**
- `tasks/install.yml` — added `easy-rsa` to package list; fixed broken task that used `notify` without an action module — replaced with `service: state=restarted`

**Lima test runner**
- `Makefile` — switched `test-run` from Ansible-over-SSH to `limactl shell` with `--connection=local`, matching the original Docker approach and avoiding SSH key auth issues
- `ansible.cfg` — removed SSH args no longer needed; set `roles_path = ..` so Ansible resolves the role by its directory name
- `tests/lima/openvpn-test.yaml` — added `ansible` to the provision script