### PR TITLE
Migrate to Debian 12 + easy-rsa v3, switch test runner to Ansible SSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SHELL := /usr/bin/env bash
 LIMA_VM      := openvpn-test
 LIMA_CONFIG  := tests/lima/$(LIMA_VM).yaml
 PLAYBOOK     := tests/main.yml
+SSH_CFG      := /tmp/lima-$(LIMA_VM)-ssh.cfg
 
 GREEN := \033[0;32m
 CYAN  := \033[0;36m
@@ -36,14 +37,14 @@ test-start: ## Start the Lima test VM (Debian 12)
 	@limactl start $(LIMA_CONFIG)
 	@echo -e "$(GREEN)[test]$(NC) VM ready."
 
-test-run: ## Run the Ansible role against the Lima VM (runs playbook inside VM via limactl shell)
-	@echo -e "$(GREEN)[test]$(NC) Running playbook inside Lima VM '$(LIMA_VM)'..."
-	@limactl shell $(LIMA_VM) -- sudo bash -c \
-	  "cd /Users/$(shell whoami)/development/ansible-openvpn-docker && \
-	   ansible-playbook $(PLAYBOOK) \
-	     -i 'localhost,' \
-	     --connection=local \
-	     --skip-tags 'addclient,docker'"
+test-run: ## Run the Ansible role against the Lima VM over SSH
+	@echo -e "$(GREEN)[test]$(NC) Generating SSH config for Lima VM '$(LIMA_VM)'..."
+	@limactl show-ssh $(LIMA_VM) --format config > $(SSH_CFG)
+	@echo -e "$(GREEN)[test]$(NC) Running playbook against Lima VM '$(LIMA_VM)' over SSH..."
+	@ansible-playbook $(PLAYBOOK) \
+	  -i "lima-$(LIMA_VM)," \
+	  -e "ansible_ssh_extra_args='-F $(SSH_CFG)'" \
+	  --skip-tags "addclient,docker"
 
 test-stop: ## Stop and delete the Lima test VM
 	@echo -e "$(GREEN)[test]$(NC) Stopping Lima VM '$(LIMA_VM)'..."

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 # Allow Ansible to find the role by its directory name when run from project root
 # Set to parent dir so Ansible resolves 'ansible-openvpn-docker' as this project's folder
 roles_path = ..
+interpreter_python = /usr/bin/python3
 
 [ssh_connection]
 pipelining = true

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,5 +4,4 @@
 roles_path = ..
 
 [ssh_connection]
-# No SSH needed — playbook runs inside the Lima VM via limactl shell --connection=local
 pipelining = true

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,20 +1,20 @@
 {% if local != true %}
-local {{ ansible_eth0.ipv4.address }}
+local {{ ansible_facts['eth0']['ipv4']['address'] }}
 {% else  %}
 local {{ remote_ip }}
 {% endif %}
 port {{ ovpn_port }}
 proto {{ proto }}
 dev {{ connection_proto }}
-{%- if ansible_os_family == "Windows" -%}
+{%- if ansible_facts['os_family'] == "Windows" -%}
 dev-node MyTap
 {%- endif %}
 
-ca {{ easy_rsa_cert_dir}}/ca.crt
-cert {{ easy_rsa_cert_dir }}/{{ easy_rsa_keys.common_name }}.crt
-key {{ easy_rsa_cert_dir }}/{{ easy_rsa_keys.common_name }}.key  # This file should be kept secret
+ca {{ easy_rsa_cert_dir }}/ca.crt
+cert {{ easy_rsa_server_crt_file }}
+key {{ easy_rsa_server_key_file }}  # This file should be kept secret
 
-dh {{ easy_rsa_cert_dir }}/dh1024.pem
+dh {{ easy_rsa_dh_file }}
 {% if server_bridge %}
 server-bridge 10.8.0.4 255.255.255.0 10.8.0.50 10.8.0.100
 {% else %}

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -31,11 +31,11 @@ mounts:
 ssh:
   loadDotSSHPubKeys: true
 
-# Install Python3 (required by Ansible) on first boot
+# Install Python3 (required by Ansible on the managed node) on first boot
 provision:
   - mode: system
     script: |
       #!/bin/bash
       set -e
       apt-get update -qq
-      apt-get install -y -qq python3 python3-apt ansible
+      apt-get install -y -qq python3 python3-apt


### PR DESCRIPTION
## What
Migrate the ansible-openvpn-docker role from Debian 8 (jessie) + easy-rsa v2 to Debian 12 (bookworm) + easy-rsa v3, and replace in-VM playbook execution with standard Ansible SSH.

## Why
Debian jessie is EOL and easy-rsa v2 scripts (`pkitool`, `build-dh`) no longer exist in Debian 12. The test runner was shelling into the Lima VM to run Ansible locally, which bypassed normal SSH-based Ansible behavior.

## Changes

**easy-rsa v3 migration**
- `tasks/easy-rsa.yml` — full rewrite using `easyrsa` CLI subcommands (`init-pki`, `build-ca`, `gen-req`, `sign-req`, `gen-dh`) with `EASYRSA_*` env vars; removes PKI `vars` template after `init-pki` to avoid conflict with system vars
- `vars/main.yml` — updated cert paths to v3 layout (`issued/`, `private/`, `dh.pem`)
- `templates/server.conf.j2` — use `easy_rsa_server_crt_file`, `easy_rsa_server_key_file`, `easy_rsa_dh_file` vars; replace deprecated `ansible_eth0`/`ansible_os_family` with `ansible_facts[]` syntax

**Test runner (Lima SSH)**
- `Makefile` — `test-run` now uses `limactl show-ssh` to write a temp SSH config then runs `ansible-playbook` from the host with `-F` SSH config file; removes in-VM shell approach
- `tests/lima/openvpn-test.yaml` — remove `ansible` from VM provision (managed node only needs `python3`, `python3-apt`)
- `ansible.cfg` — add `interpreter_python = /usr/bin/python3` to suppress discovery warning

**Other fixes**
- `handlers/main.yml` — removed `handlers:` wrapper key (must be a bare list)
- `tasks/install.yml` — added `easy-rsa` to package list; fixed task using `notify` without a module