### PR TITLE
feat: end-to-end client VM tunnel test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,36 @@
 # Makefile – ansible-openvpn-docker
 #
 # Targets
-#   make test-start    Start the Lima test VM
-#   make test-run      Run the Ansible role against the Lima VM
-#   make test-stop     Stop and delete the Lima test VM
-#   make test          Full cycle: start → run → stop
-#   make docker-build  Build the Docker image (standalone mode)
+#   make test-start      Start the server Lima VM
+#   make test-run        Run the Ansible role against the server VM
+#   make test-stop       Stop and delete the server Lima VM
+#   make client-start    Start the client Lima VM
+#   make client-run      Generate client cert on server, push to client VM
+#   make client-stop     Stop and delete the client Lima VM
+#   make test            Full cycle: start → run → stop
+#   make docker-build    Build the Docker image (standalone mode)
 # ──────────────────────────────────────────────────────────────────────────────
 
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -euo pipefail -c
 .DEFAULT_GOAL := help
 
-LIMA_VM      := openvpn-test
-LIMA_CONFIG  := tests/lima/$(LIMA_VM).yaml
-PLAYBOOK     := tests/main.yml
-SSH_CFG      := /tmp/lima-$(LIMA_VM)-ssh.cfg
+LIMA_VM        := openvpn-test
+LIMA_CONFIG    := tests/lima/$(LIMA_VM).yaml
+PLAYBOOK       := tests/main.yml
+SSH_CFG        := /tmp/lima-$(LIMA_VM)-ssh.cfg
+
+LIMA_CLIENT    := openvpn-client
+CLIENT_CONFIG  := tests/lima/$(LIMA_CLIENT).yaml
+CLIENT_PLAYBOOK := tests/client.yml
+CLIENT_SSH_CFG := /tmp/lima-$(LIMA_CLIENT)-ssh.cfg
+CLIENT_INV     := /tmp/lima-client-inventory.ini
 
 GREEN := \033[0;32m
 CYAN  := \033[0;36m
 NC    := \033[0m
 
-.PHONY: help test-start test-run test-stop test docker-build
+.PHONY: help test-start test-run test-stop client-start client-run client-stop test docker-build
 
 help: ## Show available targets
 	@echo ""
@@ -46,14 +55,36 @@ test-run: ## Run the Ansible role against the Lima VM over SSH
 	  -e "ansible_ssh_extra_args='-F $(SSH_CFG)'" \
 	  --skip-tags "addclient,docker"
 
-test-stop: ## Stop and delete the Lima test VM
+test-stop: ## Stop and delete the server Lima VM
 	@echo -e "$(GREEN)[test]$(NC) Stopping Lima VM '$(LIMA_VM)'..."
 	@limactl stop $(LIMA_VM) 2>/dev/null || true
 	@limactl delete $(LIMA_VM) 2>/dev/null || true
-	@rm -f /tmp/lima-$(LIMA_VM)-ssh.cfg
+	@rm -f $(SSH_CFG)
 	@echo -e "$(GREEN)[test]$(NC) VM removed."
 
-test: test-start test-run test-stop ## Full test cycle: start → run → stop
+client-start: ## Start the client Lima VM (Debian 12)
+	@echo -e "$(GREEN)[client]$(NC) Starting Lima VM '$(LIMA_CLIENT)'..."
+	@limactl start $(CLIENT_CONFIG)
+	@echo -e "$(GREEN)[client]$(NC) VM ready."
+
+client-run: ## Generate client cert on server, distribute certs and config to client VM
+	@echo -e "$(GREEN)[client]$(NC) Generating SSH configs..."
+	@limactl show-ssh $(LIMA_VM) --format config > $(SSH_CFG)
+	@limactl show-ssh $(LIMA_CLIENT) --format config >> $(SSH_CFG)
+	@printf '[vpn_server]\nlima-$(LIMA_VM)\n\n[vpn_client]\nlima-$(LIMA_CLIENT)\n' > $(CLIENT_INV)
+	@echo -e "$(GREEN)[client]$(NC) Running client playbook..."
+	@ansible-playbook $(CLIENT_PLAYBOOK) \
+	  -i $(CLIENT_INV) \
+	  -e "ansible_ssh_extra_args='-F $(SSH_CFG)'"
+
+client-stop: ## Stop and delete the client Lima VM
+	@echo -e "$(GREEN)[client]$(NC) Stopping Lima VM '$(LIMA_CLIENT)'..."
+	@limactl stop $(LIMA_CLIENT) 2>/dev/null || true
+	@limactl delete $(LIMA_CLIENT) 2>/dev/null || true
+	@rm -f $(CLIENT_SSH_CFG) $(CLIENT_INV) /tmp/openvpn-testclient
+	@echo -e "$(GREEN)[client]$(NC) VM removed."
+
+test: test-start test-run test-stop ## Full server test cycle: start → run → stop
 
 docker-build: ## Build the Docker image
 	@docker build -t openvpn -f tests/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ test-run: ## Run the Ansible role against the Lima VM over SSH
 	@ansible-playbook $(PLAYBOOK) \
 	  -i "lima-$(LIMA_VM)," \
 	  -e "ansible_ssh_extra_args='-F $(SSH_CFG)'" \
+	  -e "local=lima" \
 	  --skip-tags "addclient,docker"
 
 test-stop: ## Stop and delete the server Lima VM

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 #   make client-start    Start the client Lima VM
 #   make client-run      Generate client cert on server, push to client VM
 #   make client-stop     Stop and delete the client Lima VM
-#   make test            Full cycle: start → run → stop
+#   make test            Server-only test cycle: start → run → stop
+#   make test-e2e        Full end-to-end cycle: server + client + tunnel assert
 #   make docker-build    Build the Docker image (standalone mode)
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -31,7 +32,7 @@ GREEN := \033[0;32m
 CYAN  := \033[0;36m
 NC    := \033[0m
 
-.PHONY: help test-start test-run test-stop client-start client-run client-stop test docker-build
+.PHONY: help test-start test-run test-stop client-start client-run client-stop test test-e2e docker-build
 
 help: ## Show available targets
 	@echo ""
@@ -84,7 +85,9 @@ client-stop: ## Stop and delete the client Lima VM
 	@rm -f $(CLIENT_SSH_CFG) $(CLIENT_INV) /tmp/openvpn-testclient
 	@echo -e "$(GREEN)[client]$(NC) VM removed."
 
-test: test-start test-run test-stop ## Full server test cycle: start → run → stop
+test: test-start test-run test-stop ## Server-only test cycle: start → run → stop
+
+test-e2e: test-start test-run client-start client-run client-stop test-stop ## Full end-to-end cycle: server + client + tunnel assertion
 
 docker-build: ## Build the Docker image
 	@docker build -t openvpn -f tests/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ brew install socket_vmnet
 sudo launchctl load /opt/homebrew/Cellar/socket_vmnet/1.2.2/share/doc/socket_vmnet/launchd/io.github.lima-vm.socket_vmnet.plist
 ```
 
-Both Lima VM configs use `networks: [{lima: shared}]` which relies on `socket_vmnet` being available.
+Both Lima VM configs use `vzNAT` (for internet access) plus `lima: shared` (for VM-to-VM). The `lima: shared` network relies on `socket_vmnet` being available.
 
 ## Troubleshooting
 
@@ -119,7 +119,7 @@ limactl shell openvpn-test -- ip -4 addr show eth0
 ```
 
 **Both VMs have the same IP (ECONNREFUSED)**
-Lima's default `vzNAT` gives each VM an isolated NAT — VMs cannot reach each other and both get `192.168.5.15`. Fix: install and start `socket_vmnet` (see prerequisites above), then recreate the VMs with `make test-stop && make test-start`.
+Lima's default `vzNAT` gives each VM an isolated NAT — VMs cannot reach each other and both get `192.168.5.15`. The Lima configs use both `vzNAT: true` (internet) and `lima: shared` (VM-to-VM). Fix: start `socket_vmnet` (see prerequisites above), then recreate the VMs with `make test-stop && make client-stop && make test-start`.
 
 **OpenVPN server not running on server VM**
 On Debian 12 the service is `openvpn@server`, not `openvpn`. Verify:

--- a/README.md
+++ b/README.md
@@ -74,3 +74,60 @@ make docker-build
 ```
 
 The Lima VM config is at `tests/lima/openvpn-test.yaml`. The Vagrantfile is kept for reference but is no longer maintained.
+
+## End-to-end testing with a client VM
+
+A second Lima VM (`tests/lima/openvpn-client.yaml`) acts as an OpenVPN client and verifies the tunnel comes up against the server VM.
+
+```bash
+# Start server VM and configure it first
+make test-start
+make test-run
+
+# Then run the client cycle
+make client-start   # boot Debian 12 client VM
+make client-run     # generate client cert, distribute certs, start tunnel, assert ping
+make client-stop    # destroy client VM
+
+# Or the full end-to-end cycle in one command
+make test-e2e
+```
+
+### Prerequisites for end-to-end testing
+
+VM-to-VM networking requires `socket_vmnet`. Install and start it once:
+
+```bash
+brew install socket_vmnet
+sudo launchctl load /opt/homebrew/Cellar/socket_vmnet/1.2.2/share/doc/socket_vmnet/launchd/io.github.lima-vm.socket_vmnet.plist
+```
+
+Both Lima VM configs use `networks: [{lima: shared}]` which relies on `socket_vmnet` being available.
+
+## Troubleshooting
+
+### tun0 does not come up
+
+**Symptom:** `Timeout when waiting for file /sys/class/net/tun0`
+
+Check the OpenVPN client log — it is printed automatically by the `client-run` playbook. Common causes:
+
+**Client connecting to public IP instead of Lima IP**
+The `client.conf` template can resolve to the server's public IP via `ansible_local.server.remote_ip`. The test playbook patches the `remote` line using `lineinfile` with `ansible_facts['eth0']['ipv4']['address']`. If you see the wrong IP in the log, verify the server VM's eth0:
+```bash
+limactl shell openvpn-test -- ip -4 addr show eth0
+```
+
+**Both VMs have the same IP (ECONNREFUSED)**
+Lima's default `vzNAT` gives each VM an isolated NAT — VMs cannot reach each other and both get `192.168.5.15`. Fix: install and start `socket_vmnet` (see prerequisites above), then recreate the VMs with `make test-stop && make test-start`.
+
+**OpenVPN server not running on server VM**
+On Debian 12 the service is `openvpn@server`, not `openvpn`. Verify:
+```bash
+limactl shell openvpn-test -- systemctl status openvpn@server
+# Start manually if needed:
+limactl shell openvpn-test -- sudo systemctl start openvpn@server
+```
+
+**Wrong service name caused by stale server run**
+If `make test-run` was executed before the `openvpn@server` fix, the service was never started. Run `make test-run` again after the fix to apply the corrected `install.yml`.

--- a/README.md
+++ b/README.md
@@ -47,25 +47,63 @@ Next run/build the container
 
 ## Local testing with Lima
 
-Vagrant has been replaced with [Lima](https://github.com/lima-vm/lima) for local testing. Lima runs a Debian 12 (bookworm) VM on macOS (Apple Silicon and Intel) without requiring VirtualBox or Vagrant.
+Vagrant has been replaced with [Lima](https://github.com/lima-vm/lima) for local testing. Lima runs a Debian 12 (bookworm) VM on macOS (Apple Silicon and Intel) without requiring VirtualBox or Vagrant. Ansible runs from the macOS host and connects to the VM over SSH — the VM is just a managed node.
+
+### How it works
+
+```
+macOS host
+├── ansible-playbook (runs here)
+│   └── SSH → lima-openvpn-test (Debian 12, 192.168.5.15 / 192.168.105.x)
+│               ├── installs openvpn + easy-rsa
+│               ├── builds PKI (CA, server cert, DH params, ta.key)
+│               └── starts openvpn@server
+└── SSH → lima-openvpn-client (Debian 12, 192.168.105.y)
+            ├── installs openvpn
+            ├── receives client cert/key/config from server via Ansible fetch
+            └── connects to server → tun0 up → ping 192.168.30.1 ✓
+```
+
+Lima generates an SSH config per VM (`limactl show-ssh <vm> --format config`). The Makefile writes both configs into a single temp file and passes it to Ansible via `ansible_ssh_extra_args='-F /tmp/...'` so both VMs are reachable without manual SSH setup.
 
 ### Prerequisites
 
 ```bash
-brew install lima ansible
+brew install lima ansible socket_vmnet
+sudo brew services start socket_vmnet   # required for VM-to-VM networking
 ```
 
 ### Run the tests
 
 ```bash
-# Full cycle (start VM → run role → destroy VM)
-make test
+# Server-only (installs role, starts OpenVPN)
+make test-start   # boot Debian 12 server VM
+make test-run     # configure server, build PKI, start openvpn@server
+make test-stop    # destroy server VM
 
-# Or step by step
-make test-start   # boot Debian 12 Lima VM
-make test-run     # run ansible-openvpn-docker role against the VM
-make test-stop    # destroy the VM
+# End-to-end tunnel test
+make test-start && make test-run        # configure server first
+make client-start                       # boot Debian 12 client VM
+make client-run                         # generate client cert on server,
+                                        # distribute certs to client,
+                                        # start OpenVPN client,
+                                        # assert tun0 up + ping 192.168.30.1
+make client-stop                        # destroy client VM
+
+# Full cycle in one command
+make test-e2e
 ```
+
+### Networking
+
+Each Lima VM gets two network interfaces:
+
+| Interface | Network | Purpose |
+|---|---|---|
+| `eth0` | `192.168.5.x` | vzNAT — outbound internet (apt, etc.) |
+| `lima1` | `192.168.105.x` | socket_vmnet shared — VM-to-VM |
+
+The OpenVPN server binds to all interfaces (`0.0.0.0:1194`) and the client connects via `lima1`. The VPN tunnel itself uses `192.168.30.0/28` (configurable in `defaults/main.yml`).
 
 ### Build the Docker image
 
@@ -73,61 +111,69 @@ make test-stop    # destroy the VM
 make docker-build
 ```
 
-The Lima VM config is at `tests/lima/openvpn-test.yaml`. The Vagrantfile is kept for reference but is no longer maintained.
-
-## End-to-end testing with a client VM
-
-A second Lima VM (`tests/lima/openvpn-client.yaml`) acts as an OpenVPN client and verifies the tunnel comes up against the server VM.
-
-```bash
-# Start server VM and configure it first
-make test-start
-make test-run
-
-# Then run the client cycle
-make client-start   # boot Debian 12 client VM
-make client-run     # generate client cert, distribute certs, start tunnel, assert ping
-make client-stop    # destroy client VM
-
-# Or the full end-to-end cycle in one command
-make test-e2e
-```
-
-### Prerequisites for end-to-end testing
-
-VM-to-VM networking requires `socket_vmnet`. Install and start it once:
-
-```bash
-brew install socket_vmnet
-sudo launchctl load /opt/homebrew/Cellar/socket_vmnet/1.2.2/share/doc/socket_vmnet/launchd/io.github.lima-vm.socket_vmnet.plist
-```
-
-Both Lima VM configs use `vzNAT` (for internet access) plus `lima: shared` (for VM-to-VM). The `lima: shared` network relies on `socket_vmnet` being available.
-
 ## Troubleshooting
+
+### socket_vmnet not running — VMs get the same IP
+
+**Symptom:** Both VMs show `192.168.5.15`, client gets `ECONNREFUSED`
+
+Lima's default `vzNAT` isolates each VM behind its own NAT. VM-to-VM communication requires `socket_vmnet` to be running so the shared `lima1` interface gets a unique IP per VM.
+
+```bash
+# Check if socket is present
+ls /var/run/lima/socket_vmnet.shared && echo "running" || echo "not running"
+
+# Start it
+sudo brew services start socket_vmnet
+
+# Then recreate both VMs
+make test-stop && make client-stop
+make test-start && make test-run
+make client-start && make client-run
+```
 
 ### tun0 does not come up
 
 **Symptom:** `Timeout when waiting for file /sys/class/net/tun0`
 
-Check the OpenVPN client log — it is printed automatically by the `client-run` playbook. Common causes:
+The OpenVPN client log is printed automatically. Check the remote IP being used:
 
-**Client connecting to public IP instead of Lima IP**
-The `client.conf` template can resolve to the server's public IP via `ansible_local.server.remote_ip`. The test playbook patches the `remote` line using `lineinfile` with `ansible_facts['eth0']['ipv4']['address']`. If you see the wrong IP in the log, verify the server VM's eth0:
 ```bash
-limactl shell openvpn-test -- ip -4 addr show eth0
+# Should show 192.168.105.x, not a public IP
+limactl shell openvpn-client -- cat /etc/openvpn/client/client.conf | grep ^remote
 ```
 
-**Both VMs have the same IP (ECONNREFUSED)**
-Lima's default `vzNAT` gives each VM an isolated NAT — VMs cannot reach each other and both get `192.168.5.15`. The Lima configs use both `vzNAT: true` (internet) and `lima: shared` (VM-to-VM). Fix: start `socket_vmnet` (see prerequisites above), then recreate the VMs with `make test-stop && make client-stop && make test-start`.
+If the IP is wrong, the `lineinfile` task that patches `client.conf` may not have run. Re-run `make client-run`.
 
-**OpenVPN server not running on server VM**
-On Debian 12 the service is `openvpn@server`, not `openvpn`. Verify:
+### OpenVPN server not listening / ECONNREFUSED on correct IP
+
+**Symptom:** Log shows correct `192.168.105.x:1194` but still `ECONNREFUSED`
+
 ```bash
+# Check server is listening on 0.0.0.0 (not just eth0)
+limactl shell openvpn-test -- sudo ss -ulnp | grep 1194
+
+# Check service is active
 limactl shell openvpn-test -- systemctl status openvpn@server
-# Start manually if needed:
-limactl shell openvpn-test -- sudo systemctl start openvpn@server
+
+# Restart if needed
+limactl shell openvpn-test -- sudo systemctl restart openvpn@server
 ```
 
-**Wrong service name caused by stale server run**
-If `make test-run` was executed before the `openvpn@server` fix, the service was never started. Run `make test-run` again after the fix to apply the corrected `install.yml`.
+The service is `openvpn@server` (not `openvpn`) on Debian 12. The server binds to `0.0.0.0` so it accepts connections on all interfaces including `lima1`.
+
+### Ping fails but tun0 is up
+
+**Symptom:** tun0 comes up but `ping 192.168.30.1` fails
+
+Check IP forwarding is enabled on the server VM:
+
+```bash
+limactl shell openvpn-test -- cat /proc/sys/net/ipv4/ip_forward
+# Should be 1 — set via /etc/sysctl.d/99-openvpn.conf at provision time
+```
+
+If `0`, enable it manually:
+```bash
+limactl shell openvpn-test -- sudo sysctl -w net.ipv4.ip_forward=1
+```

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: restart openvpn
   service:
-    name: openvpn
+    name: openvpn@server
     state: restarted

--- a/tasks/add_clients.yml
+++ b/tasks/add_clients.yml
@@ -39,7 +39,7 @@
 
 - name: Generate client configuration
   template:
-    src: templates/client.conf.j2
+    src: "{{ playbook_dir }}/../templates/client.conf.j2"
     dest: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
   when: not check_clients_config.stat.exists
   tags:

--- a/tasks/add_clients.yml
+++ b/tasks/add_clients.yml
@@ -1,70 +1,78 @@
 ---
-  
-  - name: Include default variables
-    include_vars:
-          file: ../defaults/main.yml
-    tags:
-      - addclient
- 
-  - name: Include vars variables
-    include_vars:
-          file: ../vars/main.yml
-    tags:
-      - addclient
 
-  - name: Checking for client configs
-    stat:
-      path: "{{ openvpn_dir }}/clients/{{ client }}/{{ client }}.tar.gz"
-    register: check_clients_config
-    tags:
-      - addclient
-  
-  - name: Create client folder
-    file:
-      path: "{{ openvpn_dir }}/clients/{{ client }}"
-      state: directory
-      mode: 0700
-    tags:
-      - addclient  
-  
-  - name: Generate client certification
-    shell: "source vars && ./pkitool {{ client }}"
-    when: not check_clients_config.stat.exists
-    args:
-      chdir: "{{ easy_rsa_dir }}"     
-      executable: /bin/bash
-    tags:
-      - addclient
-  
-  - name: Generate client configuration
-    template:
-      src=../templates/client.conf.j2
-      dest="{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
-    when: not check_clients_config.stat.exists
-    tags:
-      - addclient
-      
-  - name: Create client openvpn zip package, archive it and deletes folder
-    shell: "mv certs/{{ client }}.key clients/{{ client }}/. && mv certs/{{ client }}.crt clients/{{ client }}/. && cp certs/ca.crt clients/{{ client }}/." 
-    when: not check_clients_config.stat.exists
-    args:
-      chdir: "{{ openvpn_dir }}"
-    tags:
-      - addclient
-      
-  - name: Archive client configuration and certificates
-    shell: "cp certs/ta.key clients/{{ client }}/."
-    when: easy_rsa_keys.tls_auth == True and not check_clients_config.stat.exists
-    args:
-      chdir: "{{ openvpn_dir }}"
-    tags:
-      - addclient
-  
-  - archive:
-      path: "{{ easy_rsa_client_dir }}/{{ client }}"
-      dest: "{{ easy_rsa_client_dir }}/{{ client }}/{{ client }}.tar.gz"
-    when: not check_clients_config.stat.exists
-    tags:
-      - addclient
+- name: Check for existing client config
+  stat:
+    path: "{{ easy_rsa_client_dir }}/{{ client }}/{{ client }}.tar.gz"
+  register: check_clients_config
+  tags:
+    - addclient
 
+- name: Create client folder
+  file:
+    path: "{{ easy_rsa_client_dir }}/{{ client }}"
+    state: directory
+    mode: 0700
+  tags:
+    - addclient
 
+- name: Generate client key and certificate request
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    gen-req {{ client }} nopass
+  when: not check_clients_config.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
+  tags:
+    - addclient
+
+- name: Sign client certificate
+  command: >
+    {{ easy_rsa_dir }}/easyrsa
+    --pki-dir={{ easy_rsa_cert_dir }}
+    sign-req client {{ client }}
+  when: not check_clients_config.stat.exists
+  environment:
+    EASYRSA_BATCH: "1"
+  tags:
+    - addclient
+
+- name: Generate client configuration
+  template:
+    src: templates/client.conf.j2
+    dest: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
+  when: not check_clients_config.stat.exists
+  tags:
+    - addclient
+
+- name: Collect client certificates and keys
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ easy_rsa_client_dir }}/{{ client }}/"
+    remote_src: true
+  loop:
+    - { src: "{{ easy_rsa_cert_dir }}/issued/{{ client }}.crt" }
+    - { src: "{{ easy_rsa_cert_dir }}/private/{{ client }}.key" }
+    - { src: "{{ easy_rsa_cert_dir }}/ca.crt" }
+  when: not check_clients_config.stat.exists
+  tags:
+    - addclient
+
+- name: Collect tls-auth key
+  copy:
+    src: "{{ easy_rsa_cert_dir }}/ta.key"
+    dest: "{{ easy_rsa_client_dir }}/{{ client }}/"
+    remote_src: true
+  when:
+    - easy_rsa_keys.tls_auth == True
+    - not check_clients_config.stat.exists
+  tags:
+    - addclient
+
+- name: Archive client configuration and certificates
+  archive:
+    path: "{{ easy_rsa_client_dir }}/{{ client }}"
+    dest: "{{ easy_rsa_client_dir }}/{{ client }}/{{ client }}.tar.gz"
+  when: not check_clients_config.stat.exists
+  tags:
+    - addclient

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -88,7 +88,7 @@
 
 - name: Restart openvpn service
   service:
-    name: openvpn
+    name: openvpn@server
     state: restarted
   tags:
     - vm

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -86,9 +86,3 @@
   tags:
     - install
 
-- name: Restart openvpn service
-  service:
-    name: openvpn@server
-    state: restarted
-  tags:
-    - vm

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -81,8 +81,9 @@
 
 - name: Server configuration file
   template:
-    src=templates/server.conf.j2
-    dest="{{ openvpn_dir }}/server.conf"
+    src: templates/server.conf.j2
+    dest: "{{ openvpn_dir }}/server.conf"
+  notify: restart openvpn
   tags:
     - install
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,15 @@
 
 - include_tasks: install.yml
 - include_tasks: easy-rsa.yml
+
+- name: Start openvpn server service
+  service:
+    name: openvpn@server
+    state: started
+    enabled: true
+  tags:
+    - install
+
 - include_tasks: add_clients.yml
   tags:
     - addclient

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Start openvpn server service
   service:
     name: openvpn@server
-    state: started
+    state: restarted
     enabled: true
   tags:
     - install

--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -8,7 +8,7 @@ proto {{ proto }}
 {% if local == false %}
 remote {{ ansible_local.server.remote_ip }} {{ ovpn_port }}
 {% elif local == true %}
-remote {{ ansible_default_ipv4.address }} {{ ovpn_port }}
+remote {{ ansible_facts['default_ipv4']['address'] }} {{ ovpn_port }}
 {% else %}
 remote {{ remote_server }} {{ ovpn_port }}
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,6 +1,6 @@
-{% if local != true %}
+{% if local == false %}
 local {{ ansible_facts['eth0']['ipv4']['address'] }}
-{% else  %}
+{% elif local == true %}
 local {{ remote_ip }}
 {% endif %}
 port {{ ovpn_port }}

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -14,14 +14,11 @@
     - name: Generate client cert on server
       include_tasks: "{{ playbook_dir }}/../tasks/add_clients.yml"
 
-    - name: Regenerate client.conf with server Lima IP
-      template:
-        src: "{{ playbook_dir }}/../templates/client.conf.j2"
-        dest: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
-      vars:
-        # Use eth0 explicitly — default_ipv4 resolves to the public IP on Lima
-        remote_server: "{{ ansible_facts['eth0']['ipv4']['address'] }}"
-        local: "lima"
+    - name: Set correct remote IP in client.conf (Lima eth0, not public IP)
+      lineinfile:
+        path: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
+        regexp: '^remote '
+        line: "remote {{ ansible_facts['eth0']['ipv4']['address'] }} {{ ovpn_port }}"
 
     - name: Fetch client certs and config to controller
       fetch:
@@ -74,6 +71,11 @@
       fail:
         msg: "/dev/net/tun not available in this Lima VM — TUN kernel module may not be loaded"
       when: not tun_dev.stat.exists
+
+    - name: Stop any existing OpenVPN process
+      command: pkill openvpn
+      failed_when: false
+      changed_when: false
 
     - name: Start OpenVPN client
       command: >

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -13,6 +13,10 @@
         - "{{ playbook_dir }}/../defaults/main.yml"
         - "{{ playbook_dir }}/../vars/main.yml"
 
+    - name: Set local to true so client.conf uses server Lima IP
+      set_fact:
+        local: true
+
     - name: Generate client cert and config on server
       include_tasks: "{{ playbook_dir }}/../tasks/add_clients.yml"
 

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -37,6 +37,7 @@
   become: true
   vars:
     client: testclient
+    vpn_server_tun_ip: "192.168.30.1"  # server tun0 — first IP of vpn_network in defaults/main.yml
   tasks:
     - name: Install openvpn
       apt:
@@ -107,11 +108,11 @@
       when: tun_wait is failed
 
     - name: Ping VPN server through tunnel
-      command: ping -c 3 -W 2 10.8.0.1
+      command: "ping -c 3 -W 2 {{ vpn_server_tun_ip }}"
       register: ping_result
       changed_when: false
 
     - name: Tunnel assertion result
       debug:
-        msg: "Tunnel is UP — ping to 10.8.0.1 succeeded"
+        msg: "Tunnel is UP — ping to {{ vpn_server_tun_ip }} succeeded"
       when: ping_result.rc == 0

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -28,12 +28,18 @@
         - "{{ easy_rsa_client_dir }}/{{ client }}/ta.key"
         - "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
 
-# Play 2: Copy certs and config to client VM
+# Play 2: Install OpenVPN, copy certs and config to client VM
 - hosts: vpn_client
   become: true
   vars:
     client: testclient
   tasks:
+    - name: Install openvpn
+      apt:
+        pkg: openvpn
+        state: present
+        update_cache: true
+
     - name: Create client cert directory
       file:
         path: /etc/openvpn/client

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -1,0 +1,53 @@
+---
+# Play 1: Generate client cert on server and fetch files to controller
+- hosts: vpn_server
+  become: true
+  vars:
+    client: testclient
+    # local: true makes client.conf use the server's own Lima IP
+    local: true
+  tasks:
+    - name: Include role defaults and vars
+      include_vars: "{{ item }}"
+      loop:
+        - "{{ playbook_dir }}/../defaults/main.yml"
+        - "{{ playbook_dir }}/../vars/main.yml"
+
+    - name: Generate client cert and config on server
+      include_tasks: "{{ playbook_dir }}/../tasks/add_clients.yml"
+
+    - name: Fetch client certs and config to controller
+      fetch:
+        src: "{{ item }}"
+        dest: "/tmp/openvpn-{{ client }}/"
+        flat: true
+      loop:
+        - "{{ easy_rsa_client_dir }}/{{ client }}/{{ client }}.crt"
+        - "{{ easy_rsa_client_dir }}/{{ client }}/{{ client }}.key"
+        - "{{ easy_rsa_client_dir }}/{{ client }}/ca.crt"
+        - "{{ easy_rsa_client_dir }}/{{ client }}/ta.key"
+        - "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
+
+# Play 2: Copy certs and config to client VM
+- hosts: vpn_client
+  become: true
+  vars:
+    client: testclient
+  tasks:
+    - name: Create client cert directory
+      file:
+        path: /etc/openvpn/client
+        state: directory
+        mode: 0700
+
+    - name: Copy client certs and config
+      copy:
+        src: "/tmp/openvpn-{{ client }}/{{ item.name }}"
+        dest: "/etc/openvpn/client/{{ item.dest }}"
+        mode: "{{ item.mode }}"
+      loop:
+        - { name: "ca.crt",           dest: "ca.crt",           mode: "0644" }
+        - { name: "{{ client }}.crt", dest: "{{ client }}.crt", mode: "0644" }
+        - { name: "{{ client }}.key", dest: "{{ client }}.key", mode: "0600" }
+        - { name: "ta.key",           dest: "ta.key",           mode: "0600" }
+        - { name: "client.conf",      dest: "client.conf",      mode: "0600" }

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -14,11 +14,11 @@
     - name: Generate client cert on server
       include_tasks: "{{ playbook_dir }}/../tasks/add_clients.yml"
 
-    - name: Set correct remote IP in client.conf (Lima eth0, not public IP)
+    - name: Set correct remote IP in client.conf (lima1 shared network for VM-to-VM)
       lineinfile:
         path: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
         regexp: '^remote '
-        line: "remote {{ ansible_facts['eth0']['ipv4']['address'] }} {{ ovpn_port }}"
+        line: "remote {{ ansible_facts['lima1']['ipv4']['address'] }} {{ ovpn_port }}"
 
     - name: Fetch client certs and config to controller
       fetch:

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -58,6 +58,16 @@
         - { name: "ta.key",           dest: "ta.key",           mode: "0600" }
         - { name: "client.conf",      dest: "client.conf",      mode: "0600" }
 
+    - name: Check TUN device is available
+      stat:
+        path: /dev/net/tun
+      register: tun_dev
+
+    - name: Fail if TUN device is missing
+      fail:
+        msg: "/dev/net/tun not available in this Lima VM — TUN kernel module may not be loaded"
+      when: not tun_dev.stat.exists
+
     - name: Start OpenVPN client
       command: >
         openvpn
@@ -70,6 +80,22 @@
       wait_for:
         path: /sys/class/net/tun0
         timeout: 30
+      register: tun_wait
+      ignore_errors: true
+
+    - name: Show OpenVPN client log
+      command: cat /tmp/openvpn-client.log
+      register: openvpn_log
+      changed_when: false
+
+    - name: OpenVPN client log output
+      debug:
+        msg: "{{ openvpn_log.stdout_lines }}"
+
+    - name: Fail if tun0 did not come up
+      fail:
+        msg: "tun0 did not appear within 30s — see OpenVPN log above"
+      when: tun_wait is failed
 
     - name: Ping VPN server through tunnel
       command: ping -c 3 -W 2 10.8.0.1

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -57,3 +57,26 @@
         - { name: "{{ client }}.key", dest: "{{ client }}.key", mode: "0600" }
         - { name: "ta.key",           dest: "ta.key",           mode: "0600" }
         - { name: "client.conf",      dest: "client.conf",      mode: "0600" }
+
+    - name: Start OpenVPN client
+      command: >
+        openvpn
+        --config /etc/openvpn/client/client.conf
+        --cd /etc/openvpn/client
+        --daemon
+        --log /tmp/openvpn-client.log
+
+    - name: Wait for tun0 interface to come up
+      wait_for:
+        path: /sys/class/net/tun0
+        timeout: 30
+
+    - name: Ping VPN server through tunnel
+      command: ping -c 3 -W 2 10.8.0.1
+      register: ping_result
+      changed_when: false
+
+    - name: Tunnel assertion result
+      debug:
+        msg: "Tunnel is UP — ping to 10.8.0.1 succeeded"
+      when: ping_result.rc == 0

--- a/tests/client.yml
+++ b/tests/client.yml
@@ -4,8 +4,6 @@
   become: true
   vars:
     client: testclient
-    # local: true makes client.conf use the server's own Lima IP
-    local: true
   tasks:
     - name: Include role defaults and vars
       include_vars: "{{ item }}"
@@ -13,12 +11,17 @@
         - "{{ playbook_dir }}/../defaults/main.yml"
         - "{{ playbook_dir }}/../vars/main.yml"
 
-    - name: Set local to true so client.conf uses server Lima IP
-      set_fact:
-        local: true
-
-    - name: Generate client cert and config on server
+    - name: Generate client cert on server
       include_tasks: "{{ playbook_dir }}/../tasks/add_clients.yml"
+
+    - name: Regenerate client.conf with server Lima IP
+      template:
+        src: "{{ playbook_dir }}/../templates/client.conf.j2"
+        dest: "{{ easy_rsa_client_dir }}/{{ client }}/client.conf"
+      vars:
+        # Use eth0 explicitly — default_ipv4 resolves to the public IP on Lima
+        remote_server: "{{ ansible_facts['eth0']['ipv4']['address'] }}"
+        local: "lima"
 
     - name: Fetch client certs and config to controller
       fetch:

--- a/tests/lima/openvpn-client.yaml
+++ b/tests/lima/openvpn-client.yaml
@@ -22,6 +22,9 @@ cpus: 1
 memory: "512MiB"
 disk: "5GiB"
 
+networks:
+  - lima: shared
+
 ssh:
   loadDotSSHPubKeys: true
 

--- a/tests/lima/openvpn-client.yaml
+++ b/tests/lima/openvpn-client.yaml
@@ -1,0 +1,35 @@
+# Lima VM acting as an OpenVPN client for end-to-end tunnel testing
+#
+# Usage:
+#   limactl start tests/lima/openvpn-client.yaml
+#   limactl shell openvpn-client
+#   limactl stop openvpn-client && limactl delete openvpn-client
+#
+# Or via Makefile:
+#   make client-start
+#   make client-run
+#   make client-stop
+
+images:
+  # Apple Silicon (M1–M4)
+  - location: "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2"
+    arch: aarch64
+  # Intel
+  - location: "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+    arch: x86_64
+
+cpus: 1
+memory: "512MiB"
+disk: "5GiB"
+
+ssh:
+  loadDotSSHPubKeys: true
+
+# Install Python3 (required by Ansible on the managed node) on first boot
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -e
+      apt-get update -qq
+      apt-get install -y -qq python3 python3-apt

--- a/tests/lima/openvpn-client.yaml
+++ b/tests/lima/openvpn-client.yaml
@@ -23,6 +23,7 @@ memory: "512MiB"
 disk: "5GiB"
 
 networks:
+  - vzNAT: true
   - lima: shared
 
 ssh:

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -28,6 +28,9 @@ mounts:
   - location: "~"
     writable: false
 
+networks:
+  - lima: shared
+
 ssh:
   loadDotSSHPubKeys: true
 

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -29,6 +29,7 @@ mounts:
     writable: false
 
 networks:
+  - vzNAT: true
   - lima: shared
 
 ssh:

--- a/tests/lima/openvpn-test.yaml
+++ b/tests/lima/openvpn-test.yaml
@@ -32,6 +32,7 @@ ssh:
   loadDotSSHPubKeys: true
 
 # Install Python3 (required by Ansible on the managed node) on first boot
+# Enable IP forwarding so OpenVPN can route traffic through the tunnel
 provision:
   - mode: system
     script: |
@@ -39,3 +40,6 @@ provision:
       set -e
       apt-get update -qq
       apt-get install -y -qq python3 python3-apt
+      # IP forwarding — required for OpenVPN to route client traffic
+      echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-openvpn.conf
+      sysctl -p /etc/sysctl.d/99-openvpn.conf


### PR DESCRIPTION
## What
Add a second Lima VM that acts as an OpenVPN client and runs a full end-to-end tunnel test against the server VM.

## Why
The previous test setup only verified the server role ran without errors. This adds a real connectivity assertion: a client VM generates a certificate, connects over OpenVPN, and pings the server through the tunnel.

## Changes

**New end-to-end test infrastructure**
- `tests/lima/openvpn-client.yaml` — Debian 12 client VM config with `vzNAT` + `lima: shared` networking (requires `socket_vmnet` for VM-to-VM)
- `tests/client.yml` — two-play playbook: generates client cert on server, fetches certs to controller, installs OpenVPN on client, starts tunnel, asserts `tun0` up and pings `192.168.30.1`
- `Makefile` — `client-start`, `client-run`, `client-stop` targets; merges both VM SSH configs into a single `-F` file; `test-e2e` for full cycle

**Networking fixes for Lima**
- Both Lima VM configs use `vzNAT: true` + `lima: shared` so VMs get internet (`eth0`) and VM-to-VM (`lima1`) interfaces
- OpenVPN server binds to `0.0.0.0` in test mode (pass `local=lima` from Makefile) so it accepts connections on `lima1`
- `tests/client.yml` patches `remote` in `client.conf` via `lineinfile` using `ansible_facts['lima1']['ipv4']['address']`

**Role fixes**
- `tasks/add_clients.yml` — full rewrite for easy-rsa v3 (`gen-req`/`sign-req client`), correct `issued/`/`private/` cert paths, named archive task
- `tasks/main.yml` — service start moved after `easy-rsa.yml` so PKI exists before `openvpn@server` starts
- `tasks/install.yml` — `notify: restart openvpn` on server config template; removed premature service restart
- `handlers/main.yml` — service name corrected to `openvpn@server` (Debian 12 systemd instance)
- `templates/server.conf.j2` — `local` directive omitted when non-boolean `local` is passed
- `templates/client.conf.j2` — `ansible_default_ipv4` replaced with `ansible_facts[]` syntax
- `ansible.cfg` — `interpreter_python = /usr/bin/python3`

**Docs**
- `README.md` — architecture diagram, networking table, full test command reference, troubleshooting section covering all common failure modes

Closes #10 #11 #12 #13 #14 #15