### PR TITLE
fix: modernize Docker build and add container testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,74 @@ The OpenVPN server binds to all interfaces (`0.0.0.0:1194`) and the client conne
 make docker-build
 ```
 
+## Testing with Docker
+
+You can test the full server + client flow using two Docker containers on a shared bridge network.
+
+### Build and start the server
+
+```bash
+make docker-build
+docker network create vpn-test
+docker run -d --name openvpn-server --cap-add=NET_ADMIN --network vpn-test -p 1194:1194/udp openvpn
+```
+
+### Generate a client certificate
+
+```bash
+docker exec openvpn-server ansible-playbook \
+  /etc/ansible/roles/ansible-openvpn-docker/tests/main.yml \
+  -i 'localhost,' --connection=local --tags "addclient" \
+  -e "client=testclient" -e "local=container" \
+  -e "remote_server=$(docker inspect openvpn-server --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' | awk '{print $NF}')"
+```
+
+### Extract the client bundle
+
+```bash
+docker cp openvpn-server:/etc/openvpn/clients/testclient/testclient.tar.gz /tmp/
+mkdir -p ~/testclient && tar -xzf /tmp/testclient.tar.gz -C ~/testclient
+```
+
+### Build and run the client container
+
+Create `~/testclient/Dockerfile`:
+
+```dockerfile
+FROM openvpn
+COPY . /vpn/
+CMD ["bash", "-c", "mkdir -p /dev/net && [ ! -c /dev/net/tun ] && mknod /dev/net/tun c 10 200; cd /vpn && openvpn --config client.conf"]
+```
+
+Update the remote address and connect:
+
+```bash
+SERVER_IP=$(docker inspect openvpn-server --format '{{(index .NetworkSettings.Networks "vpn-test").IPAddress}}')
+sed -i "s/^remote .*/remote $SERVER_IP 1194/" ~/testclient/client.conf
+
+docker build -t openvpn-client ~/testclient/
+docker run --rm --cap-add=NET_ADMIN --network vpn-test openvpn-client
+```
+
+### Expected output
+
+```
+[VPN] Peer Connection Initiated with [AF_INET]<server_ip>:1194
+TUN/TAP device tun0 opened
+net_addr_ptp_v4_add: 192.168.30.6 peer 192.168.30.5 dev tun0
+Initialization Sequence Completed
+```
+
+The client receives a VPN IP in the `192.168.30.0/28` range and the tunnel is up.
+
+### Clean up
+
+```bash
+docker stop openvpn-server
+docker network rm vpn-test
+docker rmi openvpn-client
+```
+
 ## Troubleshooting
 
 ### socket_vmnet not running — VMs get the same IP

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: openvpn@server
     state: restarted
+  when: local != 'container'

--- a/scripts/setup
+++ b/scripts/setup
@@ -5,4 +5,4 @@ echo "### Configuring openvpn server ###"
 [ "$(ls -A /etc/ansible/roles/ansible-openvpn-docker)" ] && \
 	git pull || \
 	git clone https://github.com/Sifungurux/ansible-openvpn-docker.git .
-ansible-playbook tests/main.yml -i 'localhost,' --connection=local --skip-tags "addclient, docker"
+ansible-playbook tests/main.yml -i 'localhost,' --connection=local --skip-tags "addclient,docker" -e "local=container"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
     enabled: true
   tags:
     - install
+    - docker
 
 - include_tasks: add_clients.yml
   tags:

--- a/templates/ovpn.j2
+++ b/templates/ovpn.j2
@@ -9,7 +9,5 @@ if [ ! -c /dev/net/tun ]; then
     mknod /dev/net/tun c 10 200
 fi
 
-echo "Running openvpn"
-/etc/init.d/openvpn start
-/etc/init.d/openvpn status
-exec /bin/bash
+echo "Starting OpenVPN server"
+exec openvpn --config /etc/openvpn/server.conf

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,16 +1,18 @@
 FROM debian:bookworm
 
-#VOLUME ["/etc/openvpn/certs", "/etc/openvpn/clients"
-
 RUN apt-get update && \
- apt-get -y upgrade && \
- apt-get install -y git ansible openvpn && \
- mkdir -p /etc/ansible/roles/ansible-openvpn-docker &&  \
- cd /etc/ansible/roles/ansible-openvpn-docker && \
- git clone https://github.com/Sifungurux/ansible-openvpn-docker.git . && \ 
- ansible-playbook tests/main.yml -i 'localhost,' --connection=local --skip-tags "addclient, docker"
+    apt-get -y upgrade && \
+    apt-get install -y ansible openvpn easy-rsa python3 python3-apt
 
- # Change this line to match your own repo if forked
+COPY . /etc/ansible/roles/ansible-openvpn-docker/
+
+RUN cd /etc/ansible/roles/ansible-openvpn-docker && \
+    ansible-playbook tests/main.yml \
+      -i 'localhost,' \
+      --connection=local \
+      --skip-tags "addclient,docker" \
+      -e "local=container"
+
 EXPOSE 1194/tcp
 EXPOSE 1194/udp
 CMD ["ovpn"]


### PR DESCRIPTION
## What
Modernizes the Docker build pipeline and adds a full Docker-based server+client testing guide to the README.

## Why
The old Dockerfile cloned the repo at build time (fragile, slow, requires internet), and the `ovpn` startup script called the deprecated `/etc/init.d/openvpn` which doesn't work on Debian 12. The container would build but fail to start OpenVPN.

## Changes
- **`tests/Dockerfile`** — replace git clone at build time with `COPY . /role/`; add missing `easy-rsa`, `python3`, `python3-apt` packages; pass `-e "local=container"` explicitly
- **`templates/ovpn.j2`** — replace `/etc/init.d/openvpn start` with `exec openvpn --config /etc/openvpn/server.conf`
- **`handlers/main.yml`** — add `when: local != 'container'` to skip service restart during container builds
- **`tasks/main.yml`** — add `docker` tag to service start task so it can be skipped during `docker build`
- **`scripts/setup`** — pass `-e "local=container"` and fix tag spacing (`addclient, docker` → `addclient,docker`)
- **`README.md`** — add Docker testing section: build server, generate client cert via `docker exec`, build client container, connect over a shared bridge network